### PR TITLE
fixing duplicate media items from soclly

### DIFF
--- a/src/components/post/PostMetadataView.tsx
+++ b/src/components/post/PostMetadataView.tsx
@@ -158,7 +158,17 @@ const getImageMediaContent = (metadata: ImageMetadataDetails, authorHandle?: str
   if (attachments && Array.isArray(attachments)) {
     attachments.forEach((att: any) => {
       if (att.item && att.type) {
-        allMedia.push({ item: att.item, type: castToMediaImageType(att.type) });
+        let mediaItemAlreadyExists = false
+
+        allMedia.forEach((media) => {
+          if (media.item === att.item) mediaItemAlreadyExists = true
+        })
+
+        if (!mediaItemAlreadyExists)
+          allMedia.push({
+            item: att.item,
+            type: castToMediaImageType(att.type),
+          })
       }
     });
   }


### PR DESCRIPTION
doesn't seem like soclly is going to stop adding images and videos as the content and as the attachment too, 
and i noticed it's the exact same media urls (thank god!)
so cleaning duplicated items was easy af! 
lfg